### PR TITLE
Numpy array handling now uses utils.strtoab instead of Buffer

### DIFF
--- a/bifrost/main.js
+++ b/bifrost/main.js
@@ -155,7 +155,7 @@ class Evaluator{
             let obj = jsonVars[key];
             if (obj['type'] == 'numpy' && typeof obj['data'] === 'string'){
                 let data = obj['data'];
-                let abData = Buffer.from(data, 'base64').buffer;
+                let abData = utils.strtoab(data);
                 const npArr = npy.parseNumpyFile(abData);
                 obj = npArr;
             }


### PR DESCRIPTION
Please note than Numpy arrays continue to be represented inside of Node.js by a custom DataArray class that preserves the appropriate headers, data, shape, and type. Bifrost will automatically parses this format into the corresponding Numpy array when passing it back to Python.