### PR TITLE
Removed redirection of process stderr to stdout.

### DIFF
--- a/bifrost/main.js
+++ b/bifrost/main.js
@@ -11,12 +11,6 @@ const args      = process.argv;
 const deepEqual = require('./deepEqual.js').deepEqual;
 const SHM_FILE_NAME = args[args.length-1];
 
-
-// Begin by piping stderr into stdout
-process.stderr.pipe(process.stdout);
-
-
-
 console.log("Beginning Node Process");
 
 /**


### PR DESCRIPTION
MR for commit `ffa79402766b102f7969081804a651de6ae45279`. Addresses kernel/IO-related Jupyter Notebook failure on most systems; identification and fix are courtesy of Paul Ringseth ( @pringseth / https://github.com/pringseth ).