### PR TITLE
Updating DCP branch with critical updates from active branches.

### DIFF
--- a/bifrost/notebook.py
+++ b/bifrost/notebook.py
@@ -54,6 +54,22 @@ class BifrostMagics(Magics):
             self.shell.user_ns[key] = vars_to_sync[key]
         return
 
+    @line_magic
+    def node_file(self, filename):
+        '''
+        `%%node_file` is a line magic that sync variables between python and node,
+        executes the contents of the file in the node process and syncs the python
+        and node process once more.
+        '''
+        #look at get_ipython().user_ns <- it returns a dict of namespace in user space
+        vars_to_sync = { k: self.shell.user_ns[k] for k in self.shell.user_ns.keys() if not k.startswith('_') and k not in RESERVED }
+        try:
+            vars_to_sync = self._node.run_file(filename, vars = vars_to_sync)
+        except KeyboardInterrupt:
+            return 
+        for key in vars_to_sync.keys():
+            self.shell.user_ns[key] = vars_to_sync[key]
+        return
 
 def shutdown_hook(ipython):
     '''

--- a/bifrost/py_nodejs.py
+++ b/bifrost/py_nodejs.py
@@ -5,6 +5,7 @@ import os, sys, socket
 import subprocess, signal
 from threading import Thread, Event, Lock
 from subprocess import call, Popen, PIPE
+from pathlib import Path
 import atexit
 
 #Simple python global read write lock
@@ -170,6 +171,14 @@ class Node():
         if var_type is not str:
             var_type = str(var_type)
         self.deserializer_custom_funcs[var_type] = func
+
+    def run_file(self, filename, vars = {}, timeout=None):
+
+        script = Path(filename).read_text()
+        
+        vars = run(script, vars, timeout)
+
+        return vars
 
     def run(self, script, vars = {}, timeout=None):
         '''

--- a/bifrost/py_nodejs.py
+++ b/bifrost/py_nodejs.py
@@ -176,7 +176,7 @@ class Node():
 
         script = Path(filename).read_text()
         
-        vars = run(script, vars, timeout)
+        vars = self.run(script, vars, timeout)
 
         return vars
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "author": "Kings Distributed Systems",
   "license": "ISC",
   "dependencies": {
-    "shmmap": "git+https://github.com/chris-c-mcintyre/shmmap",
-    "mmap.js": "git+https://github.com/bungabear/mmap.js"
+    "shmmap": "git+https://github.com/chris-c-mcintyre/shmmap.js.git",
+    "mmap.js": "git+https://github.com/bungabear/mmap.js.git"
   },
   "description": "An SHM/memmap based python and node communication/evaluation tool."
 }


### PR DESCRIPTION
Corrects broken node module installation paths in the package.json when `npm i` is manually used. Adds basis for running JS files in the local directory, by filename, using Bifrost's Node.js process.

These features are already present in the `main` and `remote` branches; `dcp` branch is still in use in some applications and demos, and so is being updated accordingly.