### PR TITLE
Suppress NPM version notice

### DIFF
--- a/bifrost/py_nodejs.py
+++ b/bifrost/py_nodejs.py
@@ -68,6 +68,9 @@ class Npm():
         Also helpful to block until command completes.
         '''
 
+        # npm version notice can disrupt parsing of command outputs
+        cmd.append("--no-update-notifier")
+        
         process = Popen(
           cmd,
           cwd = self.cwd,


### PR DESCRIPTION
Version notices automatically output by NPM with regards to itself were breaking the parsing of JSON objects being output by some `npm.run` commands. This was stopping initialization of Bifrost when it occured. This commit suppresses that notice for current and future methods of the Npm class.

Resolves #41 ("NPM version notice can disrupt parsing of command outputs").