### PR TITLE
Add public group to compute_groups by default.

### DIFF
--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -52,7 +52,7 @@ class Job:
 
         # additional job properties
         self.collate_results = True
-        self.compute_groups = []
+        self.compute_groups = [{'joinKey':'public','joinSecret':''}]
         self.debug = False
         self.estimation_slices = 3
         self.greedy_estimation = False


### PR DESCRIPTION
Resolves issue of compute_groups overwriting public group even when empty, leading to impossible-to-complete jobs being posted.