### PR TITLE
First phase of improvements to shared arguments

### DIFF
--- a/bifrost/dcp/Dcp.py
+++ b/bifrost/dcp/Dcp.py
@@ -8,12 +8,22 @@ from .Job import Job
 
 # PROGRAM
 
-def compute_do(n, work_function, work_arguments = {}): # n is a mandatory argument, in conflict with spec at docs.dcp.dev
+def compute_do(n, work_function, work_arguments = [], work_keyword_arguments = {}): # n is a mandatory argument, in conflict with spec at docs.dcp.dev
+
     job = Job(list(range(n)), work_function, work_arguments = work_arguments)
     job.range_object_input = True
     return job
 
-def compute_for(input_set, work_function, work_arguments = {}):
-    job = Job(input_set, work_function, work_arguments = work_arguments)
+def compute_for(input_set, work_function, work_arguments = [], work_keyword_arguments = {}):
+
+    # handler for deprecated or incorrect args/kwargs order
+    if type(work_arguments) == dict:
+        if len(work_keyword_arguments) == 0:
+            work_keyword_arguments = work_arguments
+            work_arguments = []
+        elif type(work_keyword_arguments) == list or type(work_keyword_arguments) == tuple:
+            work_arguments, work_keyword_arguments = work_keyword_arguments, work_arguments
+
+    job = Job(input_set, work_function, work_arguments = work_arguments, work_keyword_arguments = work_keyword_arguments)
     return job
 

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -215,6 +215,7 @@ class Job:
 
         if self.node_js == True:
             work_arguments_encoded = False # self.__input_encoder(self.work_arguments)
+            work_keyword_arguments_encoded = False
 
             if len(self.work_keyword_arguments) > 0:
                 self.work_arguments.append(self.work_key_arguments)

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -20,12 +20,15 @@ from .Work import dcp_init_worker, dcp_compute_worker, js_work_function, js_depl
 
 class Job:
 
-    def __init__(self, input_set, work_function, work_arguments = {}):
+    def __init__(self, input_set, work_function, work_arguments = [], work_keyword_arguments = {}):
 
         # mandatory job arguments
         self.input_set = input_set
         self.work_function = work_function
-        self.work_arguments = work_arguments
+
+        # alternative job arguments
+        self.work_arguments = work_arguments # positional args, iterable, provided to work function in order
+        self.work_keyword_arguments = work_keyword_arguments # named args, dict, provided to work function after args
 
         # standard job properties
         self.requirements = { 'discrete': False }

--- a/bifrost/dcp/dcpDeployJob.js
+++ b/bifrost/dcp/dcpDeployJob.js
@@ -272,6 +272,7 @@
 
         sharedArguments = [
             dcp_parameters,
+            dcp_keyword_parameters,
             dcp_function,
             python_modules,
             python_packages,

--- a/bifrost/dcp/dcpDeployJob.js
+++ b/bifrost/dcp/dcpDeployJob.js
@@ -319,7 +319,7 @@
 
         let jobArguments = [];
         nodeSharedArguments.forEach(x => {
-            let myItem = Object.fromEntries(Object.entries(x));
+            let myItem = (Object.prototype.toString.call(x) == '[object Object]') ? Object.fromEntries(Object.entries(x)) : x;
             jobArguments.push(myItem);
             return [];
         });

--- a/bifrost/dcp/dcpWorkFunction.js
+++ b/bifrost/dcp/dcpWorkFunction.js
@@ -1,6 +1,7 @@
 async function workFunction(
     sliceData,// input slice, primary arg to user-provided function
-    sliceParameters,// shared parameters, secondary args to user-provided function
+    sliceParameters,// shared positional parameters, secondary args to user-provided function
+    sliceNamedParameters,// shared keyword parameters, tertiary args to user-provided function
     sliceFunction,// user-provided function to be run on input slice
     pythonModules,// user-provided python module scripts to be imported into environment
     pythonPackages,// dcp-provided pyodidie packages to be loaded into environment
@@ -288,6 +289,7 @@ async function workFunction(
 
     pyodide.globals.set('input_data', sliceData['data']);
     pyodide.globals.set('input_parameters', sliceParameters);
+    pyodide.globals.set('input_keyword_parameters', sliceNamedParameters);
 
     await pyodide.runPython(pythonComputeWorker);
 

--- a/bifrost/dcp/dcp_compute_worker.py
+++ b/bifrost/dcp/dcp_compute_worker.py
@@ -10,26 +10,37 @@ from js import dcp
 if (pickle_arguments == True):
   # decode and unpickle secondary arguments to compute function
   parameters_decoded = codecs.decode( input_parameters.encode(), 'base64' )
+  keyword_parameters_decoded = codecs.decode( input_keyword_parameters.encode(), 'base64' )
   if (compress_arguments == True):
     parameters_decompressed = zlib.decompress( parameters_decoded )
+    keyword_parameters_decompressed = zlib.decompress( keyword_parameters_decoded )
     if (colab_pickling == True):
       parameters_unpickled = pickle.loads( parameters_decompressed )
+      keyword_parameters_unpickled = pickle.loads( keyword_parameters_decompressed )
     else:
       parameters_unpickled = cloudpickle.loads( parameters_decompressed )
+      keyword_parameters_unpickled = cloudpickle.loads( keyword_parameters_decompressed )
   else:
     if (colab_pickling == True):
       parameters_unpickled = pickle.loads( parameters_decoded )
+      keyword_parameters_unpickled = pickle.loads( keyword_parameters_decoded )
     else:
       parameters_unpickled = cloudpickle.loads( parameters_decoded )
+      keyword_parameters_unpickled = cloudpickle.loads( keyword_parameters_decoded )
 elif (encode_arguments == True):
   # decode and secondary arguments to compute function
   parameters_unpickled = codecs.decode( input_parameters.encode(), 'base64' )
+  keyword_parameters_unpickled = codecs.decode( keyword_input_parameters.encode(), 'base64' )
 else:
   # degenerate pythonic EAFP pattern; consider purging in favour of JsProxy type check
   try:
     parameters_unpickled = input_parameters.to_py()
   except AttributeError:
     parameters_unpickled = input_parameters
+  try:
+    keyword_parameters_unpickled = keyword_input_parameters.to_py()
+  except AttributeError:
+    keyword_parameters_unpickled = keyword_input_parameters
 
 if (pickle_input == True):
   # decode and unpickle primary argument to compute function
@@ -75,7 +86,7 @@ else:
 
 dcp.progress()
 
-output_data_raw = compute_function( data_unpickled, **parameters_unpickled )
+output_data_raw = compute_function( data_unpickled, *parameters_unpickled, **keyword_parameters_unpickled )
 
 if (pickle_output == True):
   if (colab_pickling == True):


### PR DESCRIPTION
New format:
```job = dcp.compute_for( input_set, work_function, worker_arguments = args, worker_keyword_arguments = kwargs )```

This will be evaluated in the worker as follows:
```output_slice = work_function( input_slice, *args, **kwargs )```

Old applications and demos that pass a dict to the traditional shared_arguments spot (so passing kwargs to args, in effect) should continue to function normally, as a check is made when the job is being intialized, and the args vs kwargs substituted or swapped as required, based on presence and observed types, if those deviate from expected positions or names.

MR additionally fixes array shared arguments for Node.js workloads.

Relates to and resolves #36 (further improvements will likely be made in future, under a different issue submission)