### PR TITLE
Add ID to Python DCP Job handle

### DIFF
--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -52,6 +52,7 @@ class Job:
         self.context_id = False # Not Used
         self.scheduler = 'https://scheduler.distributed.computer' # TODO
         self.bank = False # Not Used
+        self.id = None # Assigned on job.accepted
 
         # additional job properties
         self.collate_results = True

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -346,6 +346,11 @@ class Job:
 
         node_output = node.run(self.python_deploy, run_parameters)
 
+        try:
+          self.id = node_output['jobId']
+        except:
+          print('Warning : Job ID not found.')
+
         result_set = node_output['jobOutput']
 
         for result_index, result_slice in enumerate(result_set):

--- a/bifrost/dcp/dcpDeployJob.js
+++ b/bifrost/dcp/dcpDeployJob.js
@@ -181,6 +181,8 @@
                 {
                     console.log('Accepted :', job.id);
 
+                    jobId = job.id;
+
                     // TODO : make contingent on certain conditions or flags
                     // TODO : configurable result threshold for resolving
                     // TODO : configurable timer value, flag for interval vs single-shot timeout

--- a/bifrost/dcp/dcpDeployJob.js
+++ b/bifrost/dcp/dcpDeployJob.js
@@ -410,6 +410,8 @@
         return [];
     });
 
+    jobId = null;
+
     try
     {
         jobOutput = await dcpPost(inputSet, workFunction, sharedArguments, jobMultiplier, jobLocal);

--- a/bifrost/dcp/dcpDeployJob.js
+++ b/bifrost/dcp/dcpDeployJob.js
@@ -321,6 +321,8 @@
             }
         }
 
+        if (!jobId) jobId = job.id;
+
         // this the end of the redeployment zone
 
         // nothing after this point should ever be called more than once as part of the same user-submitted job.


### PR DESCRIPTION
Implements the job.id property for the Job class, making it available from Node.js in a Python-visible variable as soon as as the "accepted" event fires, and subsequently assigns it to the new Python property as soon as that Node.js process returns.

Resolves #79 