### PR TITLE
Add file system API for Python DCP workloads

### DIFF
--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -416,6 +416,9 @@ class Job:
         # adds files to be made available in the worker virtual file system
         for file_element in file_arguments:
             element_type = type(file_element)
+            # TODO: add support for user-submitted data buffers
+            # TODO: add support for user-submitted byte strings
+            # TODO: add support for user-submitted remote file urls
             if (element_type is str):
                 self.files_path.append(file_element)
                 file_data = self.__file_writer(file_element)

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -65,6 +65,7 @@ class Job:
 
         # file system api
         self.files_data = {}
+        self.files_path = []
 
         # remote data properties
         self.remote_storage_location = False # TODO

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -224,6 +224,9 @@ class Job:
 
         from bifrost import node
 
+        if len(self.files_data) > 0:
+            self.pickle_work_function = False
+
         if self.pyodide_wheels == True:
             self.colab_pickling = True
             self.pickle_work_function = False

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -211,6 +211,15 @@ class Job:
 
         return module_encoded
 
+    def __file_writer(self, file_name):
+
+        with open(file_name, 'rb') as file_handle:
+            file_data = file_handle.read()
+
+        file_encoded = self.__input_encoder( file_data )
+
+        return file_encoded
+
     def __dcp_run(self):
 
         from bifrost import node

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -63,6 +63,9 @@ class Job:
         self.multiplier = 1
         self.local_cores = 0
 
+        # file system api
+        self.files_data = {}
+
         # remote data properties
         self.remote_storage_location = False # TODO
         self.remote_storage_params = False # TODO

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -403,6 +403,17 @@ class Job:
             else:
                 print('Warning: unsupported format for Job.imports:', element_type)
 
+    def files(self, *files_arguments):
+        # adds files to be made available in the worker virtual file system
+        for file_element in file_arguments:
+            element_type = type(file_element)
+            if (element_type is str):
+                self.files_path.append(file_element)
+            elif (element_type is list or element_type is tuple):
+                self.files(*file_element)
+            else:
+                print('Warning: unsupported format for Job.files:', element_type)
+
     def set_result_storage(self, remote_storage_location, remote_storage_params = {}):
         self.remote_storage_location = remote_storage_location
         self.remote_storage_params = remote_storage_params

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -355,6 +355,8 @@ class Job:
             'python_compress_output': self.compress_output_set,
             'python_colab_pickling': self.colab_pickling,
             'python_pyodide_wheels': self.pyodide_wheels,
+            'python_files_path': self.files_path,
+            'python_files_data': self.files_data,
         }
 
         node_output = node.run(self.python_deploy, run_parameters)

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -418,6 +418,8 @@ class Job:
             element_type = type(file_element)
             if (element_type is str):
                 self.files_path.append(file_element)
+                file_data = self.__file_writer(file_element)
+                self.files_data[file_element] = file_data
             elif (element_type is list or element_type is tuple):
                 self.files(*file_element)
             else:

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -416,7 +416,7 @@ class Job:
 
     def files(self, *files_arguments):
         # adds files to be made available in the worker virtual file system
-        for file_element in file_arguments:
+        for file_element in files_arguments:
             element_type = type(file_element)
             # TODO: add support for user-submitted data buffers
             # TODO: add support for user-submitted byte strings

--- a/bifrost/dcp/dcpDeployJob.js
+++ b/bifrost/dcp/dcpDeployJob.js
@@ -371,6 +371,8 @@
             python_compress_output,
             python_colab_pickling,
             python_pyodide_wheels,
+            python_files_path,
+            python_files_data,
         ];
     }
     else

--- a/bifrost/dcp/dcpWorkFunction.js
+++ b/bifrost/dcp/dcpWorkFunction.js
@@ -21,6 +21,8 @@ async function workFunction(
     pythonCompressOutput,// flag which indicates that the output slice should be compressed
     pythonColabPickling,// flag which indicates that all pickling was done in a colab without cloudpickle
     pythonPyodideWheels = false,// indicates a Pyodide version greater than 20, informing the initialization steps
+    pythonFilesPath = null,// list of filenames for user-submitted files to be saved to virtual file system
+    pythonFilesData = null,// encoded binary data for user-submitted files, with filenames as dict key
 )
 {
   const startTime = Date.now();

--- a/bifrost/dcp/dcpWorkFunction.js
+++ b/bifrost/dcp/dcpWorkFunction.js
@@ -374,6 +374,8 @@ async function workFunction(
 
     pyodide.globals.set('input_imports', pythonImports);
     pyodide.globals.set('input_modules', pythonModules);
+    pyodide.globals.set('input_files_path', pythonFilesPath);
+    pyodide.globals.set('input_files_data', pythonFilesData);
 
     await pyodide.runPython(pythonInitWorker);
 

--- a/bifrost/dcp/dcp_init_worker.py
+++ b/bifrost/dcp/dcp_init_worker.py
@@ -11,6 +11,9 @@ import sys
 import codecs
 import importlib.abc, importlib.util
 
+# user file loading
+import base64
+
 class StringLoader(importlib.abc.SourceLoader):
 
     def __init__(self, data):
@@ -53,7 +56,7 @@ for file_path in py_input_files_path:
 
     file_data = py_input_files_path[file_path]
 
-    file_bytes = base64.b64decode( file_data, 'base64' )
+    file_bytes = base64.b64decode( file_data )
 
     with open(file_path, 'wb') as file_handle:
         file_handle.write(file_bytes)

--- a/bifrost/dcp/dcp_init_worker.py
+++ b/bifrost/dcp/dcp_init_worker.py
@@ -45,3 +45,16 @@ for module_name in py_input_imports:
     if module_spec is None:
         module_runtime(module_name, py_input_modules[module_name])
 
+# python proxy for js encoded file binaries
+py_input_files_path = input_files_path.to_py()
+py_input_files_path = input_files_data.to_py()
+
+for file_path in py_input_files_path:
+
+    file_data = py_input_files_path[file_path]
+
+    file_bytes = base64.b64decode( file_data, 'base64' )
+
+    with open(file_path, 'wb') as file_handle:
+        file_handle.write(file_bytes)
+


### PR DESCRIPTION
Python Job handle is augmented with a job.files function, allowing user to specify file paths to local files, which Bifrost will then read and encode as binaries, transfer to the DCP workers, and write those as files under the same name and path to the virtual file system available to the Python work function.

Example:

In Job client:
```
job.requires( 'list.csv' )
```

In work function:
```
with open('list.csv', 'r') as f:
    file_data = f.read()
```
(_any normally valid Python file operations are intended to behave as expected, in the work function_)

Resolves #80 