### PR TITLE
Expand file API to input sets

### DIFF
--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -66,6 +66,7 @@ class Job:
         # file system api
         self.files_data = {}
         self.files_path = []
+        self.input_set_files = False
 
         # remote data properties
         self.remote_storage_location = False # TODO
@@ -224,6 +225,9 @@ class Job:
 
         from bifrost import node
 
+        if self.input_set_files == True:
+            self.pickle_work_function = False
+
         if len(self.files_data) > 0:
             self.pickle_work_function = False
 
@@ -296,6 +300,8 @@ class Job:
                     'index': slice_index,
                     'data': False,
                 }
+                if (self.input_set_files == True):
+                    slice_object['files'] = self.input_files(input_slice)
                 if (self.range_object_input == False):
                     if self.node_js == False:
                         if self.pickle_input_set == True:
@@ -307,6 +313,7 @@ class Job:
                     else:
                         input_slice_encoded = input_slice
                     slice_object['data'] = input_slice_encoded
+
                 input_set_encoded.append(slice_object)
 
         job_input = []
@@ -360,6 +367,7 @@ class Job:
             'python_pyodide_wheels': self.pyodide_wheels,
             'python_files_path': self.files_path,
             'python_files_data': self.files_data,
+            'python_input_set_files': self.input_set_files,
         }
 
         node_output = node.run(self.python_deploy, run_parameters)
@@ -432,6 +440,33 @@ class Job:
                 self.files(*file_element)
             else:
                 print('Warning: unsupported format for Job.files:', element_type)
+
+    def input_files(self, slice_files=[], *files_arguments):
+        if len(slice_files) == 0 and len(files_arguments) == 1 and type(files_arguments[0]) is str:
+            # if provided input for this slice was only a single string, return file object directly
+            file_path = files_arguments[0]
+            file_data = self.__file_writer(file_path)
+            slice_file = {
+                'path': file_path,
+                'data': file_data,
+            }
+            return slice_file
+        else:
+            # returns list of file names and data for an input_set slice
+            for file_element in files_arguments:
+                element_type = type(file_element)
+                if (element_type is str):
+                    file_data = self.__file_writer(file_element)
+                    slice_file = {
+                        'path': file_element,
+                        'data': file_data,
+                    }
+                    slice_files.append(slice_file)
+                elif (element_type is list or element_type is tuple):
+                    slice_files = self.input_files(slice_files, *file_element)
+                else:
+                    print('Warning: unsupported format for input files:', element_type)
+        return slice_files
 
     def set_result_storage(self, remote_storage_location, remote_storage_params = {}):
         self.remote_storage_location = remote_storage_location

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -301,7 +301,8 @@ class Job:
                     'data': False,
                 }
                 if (self.input_set_files == True):
-                    slice_object['files'] = self.input_files(input_slice)
+                    slice_object['path'] = input_slice
+                    slice_object['binary'] = self.__file_writer(input_slice)
                 if (self.range_object_input == False):
                     if self.node_js == False:
                         if self.pickle_input_set == True:
@@ -440,33 +441,6 @@ class Job:
                 self.files(*file_element)
             else:
                 print('Warning: unsupported format for Job.files:', element_type)
-
-    def input_files(self, slice_files=[], *files_arguments):
-        if len(slice_files) == 0 and len(files_arguments) == 1 and type(files_arguments[0]) is str:
-            # if provided input for this slice was only a single string, return file object directly
-            file_path = files_arguments[0]
-            file_data = self.__file_writer(file_path)
-            slice_file = {
-                'path': file_path,
-                'data': file_data,
-            }
-            return slice_file
-        else:
-            # returns list of file names and data for an input_set slice
-            for file_element in files_arguments:
-                element_type = type(file_element)
-                if (element_type is str):
-                    file_data = self.__file_writer(file_element)
-                    slice_file = {
-                        'path': file_element,
-                        'data': file_data,
-                    }
-                    slice_files.append(slice_file)
-                elif (element_type is list or element_type is tuple):
-                    slice_files = self.input_files(slice_files, *file_element)
-                else:
-                    print('Warning: unsupported format for input files:', element_type)
-        return slice_files
 
     def set_result_storage(self, remote_storage_location, remote_storage_params = {}):
         self.remote_storage_location = remote_storage_location

--- a/bifrost/dcp/dcpDeployJob.js
+++ b/bifrost/dcp/dcpDeployJob.js
@@ -373,6 +373,7 @@
             python_pyodide_wheels,
             python_files_path,
             python_files_data,
+            python_input_set_files,
         ];
     }
     else

--- a/bifrost/dcp/dcpWorkFunction.js
+++ b/bifrost/dcp/dcpWorkFunction.js
@@ -23,6 +23,7 @@ async function workFunction(
     pythonPyodideWheels = false,// indicates a Pyodide version greater than 20, informing the initialization steps
     pythonFilesPath = null,// list of filenames for user-submitted files to be saved to virtual file system
     pythonFilesData = null,// encoded binary data for user-submitted files, with filenames as dict key
+    pythonInputSetFiles = false,// flag which indicates the input slice includes a file binary
 )
 {
   const startTime = Date.now();
@@ -374,6 +375,26 @@ async function workFunction(
 
     pyodide.globals.set('input_imports', pythonImports);
     pyodide.globals.set('input_modules', pythonModules);
+
+    if (pythonInputSetFiles == true)
+    {
+        if((sliceData['files'].length == 1) && (typeof sliceData['files']['path'] !== 'undefined') && (typeof sliceData['files']['data'] !== 'undefined'))
+        {
+            let sliceFile = sliceData['files'];
+            pythonFilesPath.push(sliceFile['path']);
+            pythonFilesData.push(sliceFile['data']);
+        }
+        else
+        {
+            for (let i = 0; i < sliceData['files'].length; i++)
+            {
+                let sliceFile = sliceData['files'][i];
+                pythonFilesPath.push(sliceFile['path']);
+                pythonFilesData.push(sliceFile['data']);
+            }
+        }
+    }
+
     pyodide.globals.set('input_files_path', pythonFilesPath);
     pyodide.globals.set('input_files_data', pythonFilesData);
 

--- a/bifrost/dcp/dcpWorkFunction.js
+++ b/bifrost/dcp/dcpWorkFunction.js
@@ -21,8 +21,8 @@ async function workFunction(
     pythonCompressOutput,// flag which indicates that the output slice should be compressed
     pythonColabPickling,// flag which indicates that all pickling was done in a colab without cloudpickle
     pythonPyodideWheels = false,// indicates a Pyodide version greater than 20, informing the initialization steps
-    pythonFilesPath = null,// list of filenames for user-submitted files to be saved to virtual file system
-    pythonFilesData = null,// encoded binary data for user-submitted files, with filenames as dict key
+    pythonFilesPath = [],// list of filenames for user-submitted files to be saved to virtual file system
+    pythonFilesData = {},// encoded binary data for user-submitted files, with filenames as dict key
     pythonInputSetFiles = false,// flag which indicates the input slice includes a file binary
 )
 {
@@ -378,21 +378,8 @@ async function workFunction(
 
     if (pythonInputSetFiles == true)
     {
-        if((sliceData['files'].length == 1) && (typeof sliceData['files']['path'] !== 'undefined') && (typeof sliceData['files']['data'] !== 'undefined'))
-        {
-            let sliceFile = sliceData['files'];
-            pythonFilesPath.push(sliceFile['path']);
-            pythonFilesData.push(sliceFile['data']);
-        }
-        else
-        {
-            for (let i = 0; i < sliceData['files'].length; i++)
-            {
-                let sliceFile = sliceData['files'][i];
-                pythonFilesPath.push(sliceFile['path']);
-                pythonFilesData.push(sliceFile['data']);
-            }
-        }
+        pythonFilesPath.push(sliceFile['path']);
+        pythonFilesData[sliceFile['path']] = sliceFile['binary'];
     }
 
     pyodide.globals.set('input_files_path', pythonFilesPath);

--- a/bifrost/dcp/dcpWorkFunction.js
+++ b/bifrost/dcp/dcpWorkFunction.js
@@ -378,8 +378,8 @@ async function workFunction(
 
     if (pythonInputSetFiles == true)
     {
-        pythonFilesPath.push(sliceFile['path']);
-        pythonFilesData[sliceFile['path']] = sliceFile['binary'];
+        pythonFilesPath.push(sliceData['path']);
+        pythonFilesData[sliceData['path']] = sliceData['binary'];
     }
 
     pyodide.globals.set('input_files_path', pythonFilesPath);


### PR DESCRIPTION
Implements simple single-file slices for distributing binaries through a new flag on the Job handle.