### PR TITLE
88 Timing output flag for DCP workloads

### DIFF
--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -346,6 +346,7 @@ class Job:
             'dcp_node_js': self.node_js,
             'dcp_events': self.events,
             'dcp_kvin': self.kvin,
+            'dcp_show_timings': self.show_timings,
             'dcp_remote_flags': self.remote,
             'dcp_remote_storage_location': self.remote_storage_location,
             'dcp_remote_storage_params': self.remote_storage_params,

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -122,6 +122,7 @@ class Job:
         self.kvin = False # uses the kvin serialization library to decode job results
         self.colab_pickling = False # use non-cloud pickling for colab deployment
         self.pyodide_wheels = False # use newer version of pyodide which uses .whl packages
+        self.show_timings = False # per-slice worker, per-slice client, and total overall
 
         # work wrapper functions
         self.python_init = dcp_init_worker

--- a/bifrost/dcp/dcpDeployJob.js
+++ b/bifrost/dcp/dcpDeployJob.js
@@ -328,13 +328,16 @@
         // nothing after this point should ever be called more than once as part of the same user-submitted job.
         // time metrics especially must account for all redeployment attempts, and can never reset in between.
 
-        const averageSliceTime = jobTimings.reduce((a, b) => a + b) / jobResults.length;
-        const totalJobTime = Date.now() - jobStartTime;
+        if (dcp_show_timings)
+        {
+            const averageSliceTime = jobTimings.reduce((a, b) => a + b) / jobResults.length;
+            const totalJobTime = Date.now() - jobStartTime;
 
-        console.log('Total Elapsed Job Time: ' + (totalJobTime / 1000).toFixed(2) + ' s');
-        console.log('Mean Elapsed Worker Time Per Slice: ' + averageSliceTime + ' s');
-        console.log('Mean Elapsed Client Time Per Unique Slice: ' + ((totalJobTime / 1000) / jobResults.length).toFixed(2) + ' s');
-
+            console.log('Total Elapsed Job Time: ' + (totalJobTime / 1000).toFixed(2) + ' s');
+            console.log('Mean Elapsed Worker Time Per Slice: ' + averageSliceTime + ' s');
+            console.log('Mean Elapsed Client Time Per Unique Slice: ' + ((totalJobTime / 1000) / jobResults.length).toFixed(2) + ' s');
+        }
+        
         return jobResults;
     }
 


### PR DESCRIPTION
Added `Job.show_timings` flag, defaulted to off, to control display of per-slice and total overall timing information of DCP workloads.

Resolves #88 