### PR TITLE
Basic testing suite for Python-deployed DCP workloads.

### DIFF
--- a/tests/dcp_javascript.py
+++ b/tests/dcp_javascript.py
@@ -1,0 +1,50 @@
+from bifrost import dcp, node
+
+# Compute left Riemann sum of exp(-x^2) from 0 to b with N subintervals.
+work_function = """function workFunction(b,N){
+
+  function linspace(start, stop, num){
+    var arr = [];
+    var step = (stop - start) / (num - 1);
+    for (var i = 0; i < num; i++) {
+      arr.push(start + (step * i));
+    }
+    return arr;
+  }
+
+  let x = linspace(0,b,N+1);
+  x.pop();
+
+  let deltaX = b/N;
+  x = x.map(a => a**2);
+  I = deltaX * x.reduce((a, b) => a + b, 0);
+
+  return I;
+}"""
+
+input_set = range(25)
+
+shared_arguments = [ 100000 ]
+
+job = dcp.compute_for(input_set, work_function, shared_arguments)
+job.public['name'] = "Bifrost DCP Testing : Javascript Riemann Sums"
+job.node_js = True
+
+output_set = job.exec()
+
+node_output = node.run("""
+
+  var compareSet = [];
+  for (let i = 0; i < inputSet.length; i++)
+  {
+    const compareSlice = inputSet[i];
+    const compareResult = workFunction(compareSlice, ...sharedArguments);
+    compareSet.push(compareResult);
+  }
+
+""", { "inputSet": input_set, "sharedArguments": shared_arguments })
+
+compare_set = node_output["compareSet"]
+
+assert output_set == compare_set
+

--- a/tests/dcp_numpy.py
+++ b/tests/dcp_numpy.py
@@ -1,0 +1,27 @@
+from bifrost import dcp
+
+def work_function(b,N):
+  import numpy as np
+  x = np.linspace(0,b,N+1)
+  x_left_endpoints = x[:-1]
+  Delta_x = b/N
+  I = Delta_x * np.sum(np.exp(-x_left_endpoints**2))
+  return I
+
+input_set = range(25)
+
+shared_arguments = [100000]
+
+job = dcp.compute_for(input_set, work_function, shared_arguments)
+job.requires('numpy')
+job.public['name'] = "Bifrost DCP Testing : Numpy Riemann Sums"
+
+output_set = job.exec()
+
+compare_set = []
+for compare_slice in input_set:
+  compare_result = work_function(compare_slice, *shared_arguments)
+  compare_set.append(compare_result)
+
+assert output_set == compare_set
+

--- a/tests/dcp_scipy.py
+++ b/tests/dcp_scipy.py
@@ -1,0 +1,49 @@
+from bifrost import dcp
+
+def work_function(input_slice, fs, N):
+
+  from js import dcp
+  dcp.progress()
+
+  import numpy as np
+  from scipy import signal
+
+  np.random.seed(0)
+
+  rng = np.random.default_rng()
+
+  freq = input_slice
+
+  amp = 2*np.sqrt(2)
+  noise_power = 0.001 * fs / 2
+  time = np.arange(N) / fs
+
+  x = amp*np.sin(2*np.pi*freq*time)
+  x += rng.normal(scale=np.sqrt(noise_power), size=time.shape)
+
+  x[int(N//2):int(N//2)+10] *= 50.
+  f, Pxx_den = signal.welch(x, fs, nperseg=4096)
+
+  dcp.progress()
+
+  f_med, Pxx_den_med = signal.welch(x, fs, nperseg=4096, average='median')
+
+  return { 'f_med': f_med, 'Pxx_den_med': Pxx_den_med, }
+
+input_set = range(25)
+
+shared_arguments = {'fs': 10e3, 'N': 1e5}
+
+job = dcp.compute_for(input_set, work_function, shared_arguments)
+job.requires(['scipy'])
+job.public['name'] = "Bifrost DCP Testing : Scipy Signal"
+
+output_set = job.exec()
+
+compare_set = []
+for compare_slice in input_set:
+  compare_result = work_function(compare_slice, **shared_arguments)
+  compare_set.append(compare_result)
+
+assert output_set == compare_set
+

--- a/tests/dcp_simple.py
+++ b/tests/dcp_simple.py
@@ -1,0 +1,25 @@
+from bifrost import dcp
+
+def work_function(input_slice):
+  if (input_slice[0] % 2) == 0:
+    return input_slice[1].lower()
+  else:
+    return input_slice[1].upper()
+
+input_string = "Hello, my name is Bob, and this is my Bifrost test string!"
+input_set = []
+for idx, val in enumerate(list(input_string)):
+  input_set.append(tuple([idx, val]))
+
+job = dcp.compute_for(input_set, work_function)
+job.public['name'] = "Bifrost DCP Testing : Spongecase"
+
+output_set = job.exec()
+
+compare_set = []
+for compare_slice in input_set:
+  compare_result = work_function(compare_slice)
+  compare_set.append(compare_result)
+
+assert output_set == compare_set
+


### PR DESCRIPTION
Includes:
- `dcp_simple.py`: toy example, deploying distributed string case-changing in Python
- `dcp_javascript.py`: deploying distributed Riemann sums in Javascript
- `dcp_numpy.py`: deploying distributed Riemann sums in Python using Numpy
- `dcp_scipy.py`: deploying distributed signal functions in Python using Scipy

Relates to #95 (Strong testbed integration), but this MR alone is not sufficient to satisfy that issue.