### PR TITLE
106 Standalone DCP worker support

### DIFF
--- a/bifrost/dcp/dcpWorkFunction.js
+++ b/bifrost/dcp/dcpWorkFunction.js
@@ -178,6 +178,16 @@ async function workFunction(
 
     if (workerConfigFlags['pyodide']['wheels']) globalThis.URL = function(...args){ return args[0] };
 
+    async function wasmInstantiate(binary, info)
+    {
+      const ourModule = await new WebAssembly.Module(binary);
+      const ourInstance = await new WebAssembly.Instance(ourModule, info);
+      return {
+        module: ourModule,
+        instance: ourInstance
+      };
+    }
+    globalThis.WebAssembly.instantiate = wasmInstantiate;
     globalThis.WebAssembly.instantiateStreaming = null;
 
     function frankenDoctor

--- a/bifrost/dcp/dcpWorkFunction.js
+++ b/bifrost/dcp/dcpWorkFunction.js
@@ -389,21 +389,6 @@ async function workFunction(
 
     await pyodide.runPython(workerParameters['python_functions']['init']);
 
-    /*
-    progress(1);
-
-    pyLog.push('// PYTHON LOG STOP //');
-
-    const stopTime = ((Date.now() - startTime) / 1000).toFixed(2);
-
-    return {
-        output: 0,
-        index: sliceData['index'],
-        elapsed: stopTime,
-        stdout: pyLog,
-    };
-    */
-
     progress();
 
     pyodide.globals.set('worker_config_flags', workerConfigFlags);


### PR DESCRIPTION
Tested on web workers and standalone native works, including RPi-targeted builds.

Tested with both simple and high-intenstity Bifrost workloads and packages.

Resolves #106 