### PR TITLE
Feat/password: Add password check on python side before passing to node for unlock

### DIFF
--- a/bifrost/__init__.py
+++ b/bifrost/__init__.py
@@ -11,6 +11,10 @@ from .py_utils import is_notebook
 from .npm import Npm
 from .node import Node
 
+# Version
+
+__version__ = "0.8.1"
+
 # PROGRAM
 
 npm = Npm()

--- a/bifrost/dcp/Job.py
+++ b/bifrost/dcp/Job.py
@@ -3,6 +3,7 @@
 # python standard library
 import codecs
 import inspect
+import getpass
 import pickle
 import random
 import re
@@ -35,6 +36,7 @@ class Job:
         self.initial_slice_profile = False # Not Used
         self.slice_payment_offer = False # TODO
         self.payment_account = False
+        self.payment_account_password = ""
         self.require_path = [] # dcp pyodide packages (populated via Job.requires)
         self.module_path = False # Not Used
         self.collate_results = True
@@ -371,6 +373,7 @@ class Job:
             'job_public': self.public,
             'job_requirements': self.requirements,
             'job_payment_account': self.payment_account,
+            'job_payment_account_password': self.payment_account_password,
             'job_slice_payment_offer': self.slice_payment_offer,
         }
 
@@ -517,7 +520,7 @@ class Job:
     def on(self, event_name, event_function):
         self.events[event_name] = event_function
 
-    def exec(self, slice_payment_offer = False, slice_price = False, payment_account = False, account = False, initial_slice_profile = False):
+    def exec(self, slice_payment_offer = False, slice_price = False, payment_account = False, account = False, initial_slice_profile = False, keystore_unlocked = False):
         if ( slice_payment_offer != False ):
             self.slice_payment_offer = slice_payment_offer
         if (slice_price != False):
@@ -527,10 +530,15 @@ class Job:
         if ( account != False ):
             self.payment_account = account
         if ( initial_slice_profile != False ):
-            self.initial_slice_profile = initial_slice_profile     
+            self.initial_slice_profile = initial_slice_profile
+        if not keystore_unlocked:
+            self.unlock_keystore()
         results = self.__dcp_run()
         self.results = results
         return results
+
+    def unlock_keystore(self):
+        self.payment_account_password = getpass.getpass("Enter keystore password: ")
 
     def local_exec(self, local_cores = 1):
         self.local_cores = local_cores

--- a/bifrost/dcp/dcpDeployJob.js
+++ b/bifrost/dcp/dcpDeployJob.js
@@ -424,7 +424,11 @@ exports.deploy = async function pyjsDeployJob(
     let idKeystore = await (new dcpWallet.IdKeystore(null, ""));
 
     if (ksPassword) {
+      if (dcp_parameters['dcp_debug']) console.log("Keystore password was provided. Unlocking wallet.");
       await bankKeystore.unlock(ksPassword, 24 * 60 * 60 * 1000);
+      dcpWallet.passphrasePrompt = (message) => {
+        return ksPassword;
+      };
     }
 
     await dcpWallet.add(bankKeystore);

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setuptools.setup(
     name="Bifrost",
-    version="0.8.0",
+    version="0.8.1",
     author="Distributive",
     author_email="toolchains@distributive.network",
     description="Python to JS intercommunication and execution",


### PR DESCRIPTION
This PR adds the capability for a user to be prompted for a passphrase. Note that a user will always be prompted even if the keystore given is passphraseless unless they specify the `keystore_unlocked=True` in `job.exec`. 

